### PR TITLE
Correct format portability warnings

### DIFF
--- a/hw/arm/cortexm-mcu.c
+++ b/hw/arm/cortexm-mcu.c
@@ -71,7 +71,7 @@ static void cortexm_mcu_do_unassigned_access_callback(CPUState *cpu,
         bool is_write, bool is_exec, int opaque, unsigned size)
 {
     qemu_log_mask(LOG_TRACE,
-            "%s(addr=0x%08llX, size=%d, is_write=%s, is_exec=%s)\n",
+            "%s(addr=0x%08"PRIX64", size=%d, is_write=%s, is_exec=%s)\n",
             __FUNCTION__, addr, size, is_write ? "true" : "false",
             is_exec ? "true" : "false");
 

--- a/hw/core/loader.c
+++ b/hw/core/loader.c
@@ -885,7 +885,7 @@ int rom_add_elf_program(const char *name, void *data, size_t datasize,
 
 #if defined(CONFIG_VERBOSE)
     if (verbosity_level >= VERBOSITY_DETAILED) {
-        printf("Load %6zu bytes at 0x%08llX-0x%08llX.\n", romsize, addr, addr+romsize-1);
+        printf("Load %6zu bytes at 0x%08"PRIX64"-0x%08"PRIX64".\n", romsize, addr, addr+romsize-1);
     }
 #endif
 

--- a/hw/core/sysbus.c
+++ b/hw/core/sysbus.c
@@ -130,7 +130,7 @@ static void sysbus_mmio_map_common(SysBusDevice *dev, int n, hwaddr addr,
     assert(n >= 0 && n < dev->num_mmio);
 
 #if defined(CONFIG_GNU_ARM_ECLIPSE)
-    qemu_log_mask(LOG_TRACE, "%s(0x%08llX)\n", __FUNCTION__, addr);
+    qemu_log_mask(LOG_TRACE, "%s(0x%08"PRIX64")\n", __FUNCTION__, addr);
 #endif
 
     if (dev->mmio[n].addr == addr) {

--- a/hw/misc/peripheral-register.c
+++ b/hw/misc/peripheral-register.c
@@ -810,8 +810,8 @@ static void peripheral_register_realize_callback(DeviceState *dev, Error **errp)
     }
 
     qemu_log_mask(LOG_TRACE,
-            "%s() '%s', readable: 0x%08llX, writable: 0x%08llX, "
-                    "reset: 0x%08llX, mode: %s%s\n", __FUNCTION__, state->name,
+            "%s() '%s', readable: 0x%08"PRIX64", writable: 0x%08"PRIX64", "
+                    "reset: 0x%08"PRIX64", mode: %s%s\n", __FUNCTION__, state->name,
             state->readable_bits, state->writable_bits, state->reset_value,
             state->is_readable ? "r" : "", state->is_writable ? "w" : "");
 }

--- a/hw/misc/peripheral.c
+++ b/hw/misc/peripheral.c
@@ -77,7 +77,7 @@ static uint64_t peripheral_read_callback(void *opaque, hwaddr addr,
             state->registers[index]);
     if (reg == NULL) {
         qemu_log_mask(LOG_UNIMP, "%s: Peripheral read of size %d at offset "
-                "0x%llX not implemented.\n", object_get_typename(OBJECT(state)),
+                "0x%"PRIX64" not implemented.\n", object_get_typename(OBJECT(state)),
                 size, addr);
         return 0;
     }
@@ -128,7 +128,7 @@ static void peripheral_write_callback(void *opaque, hwaddr addr, uint64_t value,
             state->registers[index]);
     if (reg == NULL) {
         qemu_log_mask(LOG_UNIMP,
-                "%s: Write of size %d at offset 0x%llX not implemented.\n",
+                "%s: Write of size %d at offset 0x%"PRIX64" not implemented.\n",
                 object_get_typename(OBJECT(state)), size, addr);
         return;
     }

--- a/hw/misc/register-bitfield.c
+++ b/hw/misc/register-bitfield.c
@@ -258,7 +258,7 @@ static void register_bitfield_realize_callback(DeviceState *dev, Error **errp)
     }
 
     qemu_log_mask(LOG_TRACE,
-            "%s() '%s[%d:%d]', mask: 0x%llX, shift: %d, mode: %s%s\n",
+            "%s() '%s[%d:%d]', mask: 0x%"PRIX64", shift: %d, mode: %s%s\n",
             __FUNCTION__, state->name, state->first_bit,
             state->first_bit + state->width_bits + 1, state->mask, state->shift,
             state->is_readable ? "r" : "", state->is_writable ? "w" : "");

--- a/memory.c
+++ b/memory.c
@@ -411,16 +411,16 @@ static MemTxResult  memory_region_read_accessor(MemoryRegion *mr,
             ; /* Skip ITM */
         } else {
             if (size == 1) {
-                qemu_log_mask(LOG_TRACE_MR, "rd8(0x%08llX) 0x%02X)\n",
+                qemu_log_mask(LOG_TRACE_MR, "rd8(0x%08"PRIX64") 0x%02X)\n",
                         a, (uint8_t)tmp);
             } else if (size == 2){
-                qemu_log_mask(LOG_TRACE_MR, "rd16(0x%08llX) 0x%04X)\n",
+                qemu_log_mask(LOG_TRACE_MR, "rd16(0x%08"PRIX64") 0x%04X)\n",
                         a, (uint16_t)tmp);
             } else if (size == 4){
-                qemu_log_mask(LOG_TRACE_MR, "rd32(0x%08llX) 0x%08X)\n",
+                qemu_log_mask(LOG_TRACE_MR, "rd32(0x%08"PRIX64") 0x%08X)\n",
                         a, (uint32_t)tmp);
             } else {
-                qemu_log_mask(LOG_TRACE_MR, "rd(0x%08llX, %d) 0x%llX\n",
+                qemu_log_mask(LOG_TRACE_MR, "rd(0x%08"PRIX64", %d) 0x%"PRIX64"\n",
                         a, size, tmp);
             }
         }
@@ -455,16 +455,16 @@ static MemTxResult memory_region_read_with_attrs_accessor(MemoryRegion *mr,
             ; /* Skip ITM */
         } else {
             if (size == 1) {
-                qemu_log_mask(LOG_TRACE_MR, "rd8(0x%08llX) 0x%02X)\n",
+                qemu_log_mask(LOG_TRACE_MR, "rd8(0x%08"PRIX64") 0x%02X)\n",
                         a, (uint8_t)tmp);
             } else if (size == 2){
-                qemu_log_mask(LOG_TRACE_MR, "rd16(0x%08llX) 0x%04X)\n",
+                qemu_log_mask(LOG_TRACE_MR, "rd16(0x%08"PRIX64") 0x%04X)\n",
                         a, (uint16_t)tmp);
             } else if (size == 4){
-                qemu_log_mask(LOG_TRACE_MR, "rd32(0x%08llX) 0x%08X)\n",
+                qemu_log_mask(LOG_TRACE_MR, "rd32(0x%08"PRIX64") 0x%08X)\n",
                         a, (uint32_t)tmp);
             } else {
-                qemu_log_mask(LOG_TRACE_MR, "rd(0x%08llX, %d) 0x%llX\n",
+                qemu_log_mask(LOG_TRACE_MR, "rd(0x%08"PRIX64", %d) 0x%"PRIX64"\n",
                         a, size, tmp);
             }
         }
@@ -516,16 +516,16 @@ static MemTxResult memory_region_write_accessor(MemoryRegion *mr,
             ; /* Skip ITM */
         } else {
             if (size == 1) {
-                qemu_log_mask(LOG_TRACE_MR, "wr8(0x%08llX, 0x%02X)\n",
+                qemu_log_mask(LOG_TRACE_MR, "wr8(0x%08"PRIX64", 0x%02X)\n",
                         a, (uint8_t)tmp);
             } else if (size == 2){
-                qemu_log_mask(LOG_TRACE_MR, "wr16(0x%08llX, 0x%04X)\n",
+                qemu_log_mask(LOG_TRACE_MR, "wr16(0x%08"PRIX64", 0x%04X)\n",
                         a, (uint16_t)tmp);
             } else if (size == 4){
-                qemu_log_mask(LOG_TRACE_MR, "wr32(0x%08llX, 0x%08X)\n",
+                qemu_log_mask(LOG_TRACE_MR, "wr32(0x%08"PRIX64", 0x%08X)\n",
                         a, (uint32_t)tmp);
             } else {
-                qemu_log_mask(LOG_TRACE_MR, "wr(0x%08llX, 0x%llX, %d)\n",
+                qemu_log_mask(LOG_TRACE_MR, "wr(0x%08"PRIX64", 0x%"PRIX64", %d)\n",
                         a, tmp, size);
             }
         }
@@ -996,7 +996,7 @@ void memory_region_init(MemoryRegion *mr,
 {
 #if defined(CONFIG_GNU_ARM_ECLIPSE)
     if (name != NULL) {
-        qemu_log_mask(LOG_TRACE, "%s(\"%s\", 0x%llX)\n", __FUNCTION__, name, size);
+        qemu_log_mask(LOG_TRACE, "%s(\"%s\", 0x%"PRIX64")\n", __FUNCTION__, name, size);
     }
 #endif
     if (!owner) {

--- a/qom/qom-qobject.c
+++ b/qom/qom-qobject.c
@@ -26,7 +26,7 @@ static char *dump_value(QObject *value, char *buf, size_t siz)
 {
     if (value->type->code == QTYPE_QINT) {
         QInt *p = (QInt *) value;
-        snprintf(buf, siz, "%lld", p->value);
+        snprintf(buf, siz, "%" PRId64, p->value);
         return buf;
     } else if (value->type->code == QTYPE_QSTRING) {
         QString *p = (QString *) value;


### PR DESCRIPTION
These break the build with GCC 4.9, with warnings of the form:

> error: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘int64_t’

This is on a platform where int64_t is a typedef for 'long int', so
the warning is fair enough.

These have been replaced with the C99 PRI constants.
